### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Alex Johnson <alex.kattathra.johnson@gmail.com>"]
-homepage = "https://github.com/alex-kattathra-johnson/nu_plugin_ws"
+repository = "https://github.com/alex-kattathra-johnson/nu_plugin_ws"
 readme = "README.md"
 license = "MIT"
 name = "nu_plugin_ws"


### PR DESCRIPTION
According to the [manifset](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/91