### PR TITLE
Update Nushell dependencies to 0.107.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf-trait"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21eaafc770e8c073d6c3facafe7617e774305d4954aa6351b9c452eb37ee17b4"
+dependencies = [
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +216,24 @@ name = "bytesize"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
+
+[[package]]
+name = "byteyarn"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93e51d26468a15ea59f8525e0c13dc405db43e644a0b1e6d44346c72cf4cf7b"
+dependencies = [
+ "buf-trait",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -493,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.14.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -766,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -870,6 +897,18 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "lean_string"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962df00ba70ac8d5ca5c064e17e5c3d090c087fd8d21aa45096c716b169da514"
+dependencies = [
+ "castaway",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1091,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-base"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3180c7dfcc49939bba48ab823212d9d827b87545a27f9e7b78280ffb7863f43"
+checksum = "a47f179f8351f2ad4def7ca90d22bde9125434773e607e56edbbdc6a3d9e7ae9"
 dependencies = [
  "indexmap",
  "miette",
@@ -1105,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-lang"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b758824e54ae930b349fe2992d65953c89912339b5b93c1907eaf33957361e4b"
+checksum = "02d6527b17386c93a3f7848006fb0cfe360f541aeeedb94755d367c684ccc110"
 dependencies = [
  "itertools 0.14.0",
  "nu-cmd-base",
@@ -1121,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "nu-derive-value"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d1febab306f99c79b66475613292b5161ce8387a49507c0d4eb32674947ae5"
+checksum = "790ab3ef96bd1b3133389be7b9772bb46aa98fff612b3417d80f40cc2271affb"
 dependencies = [
  "heck",
  "proc-macro-error2",
@@ -1134,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de25b8ddcea0c67dd6b0e8827c7740ad5c9ab723be76a7e918c4331b768c5b93"
+checksum = "5c3ee4b666991180f7567a4673c61cd9c7eabfd43f1b1a63c890f2685b6c8ed6"
 dependencies = [
  "fancy-regex",
  "log",
@@ -1148,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "nu-experimental"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63101f1f5a94446a9d74822f927e5947d1dd694a1510a85b1b61d4da9202c8d7"
+checksum = "8e2c87f767dbbc077d6102fadbbf18e595d4845c3b90d5ab186615697587f670"
 dependencies = [
  "itertools 0.14.0",
  "thiserror 2.0.12",
@@ -1158,15 +1197,15 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa0dbf8cd49307284f7e21cac1e794c4e8dc93c767c800831a7e36e7c48a64b"
+checksum = "6be8d8ac9cf524bd2b624f3394e805d054cc4ec55addc5867336f3cc658751b0"
 
 [[package]]
 name = "nu-parser"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368c519d60cc5b3ecce83d28ac1e75cb809a9456bf971e3f3336135919c1ecce"
+checksum = "71252c586db6400b8b34b13f5c49f9b0982392073b33c18831ded6b094161562"
 dependencies = [
  "bytesize",
  "chrono",
@@ -1182,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7a0d7138ec150494d809e584a6e387f2dadb7089ae17b859a73af03c6465d1"
+checksum = "70e3110f0ee70b2dbe2ee289512d580876c3b149e43ded007b8cb8061d9cbb02"
 dependencies = [
  "dirs",
  "omnipath",
@@ -1194,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9415b93f2aefd86bffe02bc154bfffcb8e7c575601d844454edb803aa82ddf"
+checksum = "d479fae7eaf63371ee69f5092c7ea207c6486fdfa276e45d66015aeef6704f43"
 dependencies = [
  "log",
  "nix",
@@ -1210,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-core"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99a3ce4ef2de0b22e0fbcdb8f1dc32107cbaef11e6a149ba20bf809b41040f7c"
+checksum = "ead7de3022ab2ce316fc5e9cb3361be48d0493a963a28323b76b27611ccda672"
 dependencies = [
  "interprocess",
  "log",
@@ -1226,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-engine"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dbe3b5a0d977c836863a737b608e3fe58c6c11f257d053e71daff823af3e6b"
+checksum = "299e44ab59255d33d53a9a55d3f8c7cc410ae06a68d35a7fd696d07b21e64b54"
 dependencies = [
  "log",
  "nu-engine",
@@ -1243,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-protocol"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2cfe91bcfd223c6d53bb851db0cd2621b51bd4abca6f7526cf275bbf9179"
+checksum = "8081f74f009d68b842718cdfd61243be8139ba2bc585f6815b53fca63be5373d"
 dependencies = [
  "nu-protocol",
  "nu-utils",
@@ -1257,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-test-support"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78d503c91e7af47446032298d7b88ef0efb068179581e9bcd1a9451cc1496ea"
+checksum = "78661148a90b26743eb51a1a3e0762742c8371d2dc399211532f8f63101d3be5"
 dependencies = [
  "nu-ansi-term",
  "nu-cmd-lang",
@@ -1275,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389c832210b3175bc5a559c7796dee5f9fa7e51276e7d2f26fb45e8aa49fbb89"
+checksum = "21b0dd71a797fc3facf50af631774e01f5564da101c9d6c19015a5e6711d5089"
 dependencies = [
  "brotli",
  "bytes",
@@ -1315,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d6d1758b1a9c966a5c327db63c336549f3fdb85c9f398522257eeb0b75f5dd"
+checksum = "658a2171d31b4d72de1eeeabcca111f85251f4244b0684edc93048d44a29cb1e"
 dependencies = [
  "chrono",
  "itertools 0.14.0",
@@ -1335,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "nu-test-support"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db0682fa726f7d7fd38876e559fbd9d10299215ec1a2bef54f4741274c9271a"
+checksum = "51e2639787247b5265e2485265a082f478b9e15c3bbb945e6658b5b3a87bda99"
 dependencies = [
  "nu-glob",
  "nu-path",
@@ -1349,15 +1388,18 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.106.1"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1799806999aa837718ac3dd1652fb0338f1d4665561db3bb90caa7175aa7493"
+checksum = "27ee1ae2999faaf8577f55a6051ec9b02a8cae5660f323a9d332e8b6734dc24b"
 dependencies = [
+ "byteyarn",
  "crossterm",
  "crossterm_winapi",
  "fancy-regex",
+ "lean_string",
  "log",
  "lscolors",
+ "memchr",
  "nix",
  "num-format",
  "serde",
@@ -1369,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_ws"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "env_logger",
  "log",
@@ -1595,7 +1637,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.26",
 ]
 
 [[package]]
@@ -2105,15 +2147,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2941,11 +2983,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.26",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 license = "MIT"
 name = "nu_plugin_ws"
 description = "A Nushell plugin for easily streaming output from websocket endpoints"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 
 [lib]
@@ -17,13 +17,13 @@ name = "nu_plugin_ws"
 path = "src/main.rs"
 
 [dependencies]
-nu-plugin = "0.106.1"
-nu-protocol = "0.106.1"
+nu-plugin = "0.107.0"
+nu-protocol = "0.107.0"
 tungstenite = { version = "0.24.0", features = ["native-tls"] }
 url = "2.5.3"
 log = "0.4"
 env_logger = "0.11"
 
 [dev-dependencies]
-nu-test-support = "0.106.1"
-nu-plugin-test-support = "0.106.1"
+nu-test-support = "0.107.0"
+nu-plugin-test-support = "0.107.0"


### PR DESCRIPTION
## Summary
- Updated Nushell dependencies from 0.106.1 to 0.107.0
- Bumped version to 1.0.6
- Plugin now compiles and works with Nushell 0.107.0

## Changes Made
- Updated `nu-plugin`, `nu-protocol`, `nu-test-support`, and `nu-plugin-test-support` dependencies in Cargo.toml
- Incremented version number to reflect compatibility update
- Tested compilation and basic functionality with Nushell 0.107.0

## Testing
- Plugin builds successfully with `cargo build --release`
- Plugin installs and registers correctly with Nushell 0.107.0
- `help ws` command works as expected
- No compatibility issues found

This update ensures the plugin works with the latest Nushell version while maintaining all existing functionality.